### PR TITLE
Fix primary monitor detection

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -359,8 +359,13 @@ const HanabiRenderer = GObject.registerClass(
                 if (this._screenSelectionMode === 0) { // All monitors
                     createThisWindow = true;
                 } else if (this._screenSelectionMode === 1) { // Primary monitor only
-                    if (gdkMonito(gdkMonitor.get_display().get_primary_monitor() === gdkMonitor)r.is_primary()) {
-                        createThisWindow = true;
+                    if (typeof gdkMonitor.is_primary === 'function') {
+                        if (gdkMonitor.is_primary())
+                            createThisWindow = true;
+                    } else {
+                        const primaryMonitor = gdkMonitor.get_display().get_primary_monitor();
+                        if (primaryMonitor === gdkMonitor)
+                            createThisWindow = true;
                     }
                 } else if (this._screenSelectionMode === 2) { // Specific monitors
                     if (specificIndices.includes(index)) {


### PR DESCRIPTION
## Summary
- fix malformed conditional when checking for primary monitor
- fall back to check against display's primary monitor if `is_primary` isn't available

## Testing
- `npm install --no-audit --no-fund`
- `npx eslint src/renderer/renderer.js` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fa5b3de30832f957891d4f42cc06b