### PR TITLE
Fix window skip check in AutoPause

### DIFF
--- a/src/autoPause.js
+++ b/src/autoPause.js
@@ -136,7 +136,7 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
 
         _windowAdded(metaWindow, doUpdate = true) {
             // Not need to track renderer window or skip taskbar window
-            if (metaWindow.title?.includes(applicationId) | metaWindow.skip_taskbar)
+            if (metaWindow.title?.includes(applicationId) || metaWindow.skip_taskbar)
                 return;
 
             let signals = [];
@@ -173,7 +173,7 @@ const PauseOnMaximizeOrFullscreenModule = GObject.registerClass(
         }
 
         _windowRemoved(metaWindow) {
-            if (metaWindow.title?.includes(applicationId) | metaWindow.skip_taskbar)
+            if (metaWindow.title?.includes(applicationId) || metaWindow.skip_taskbar)
                 return;
 
             this._windows = this._windows.filter(window => {


### PR DESCRIPTION
## Summary
- ensure correct logical or when skipping taskbar windows in AutoPause module

## Testing
- `npm install`
- `npx eslint src/autoPause.js`

------
https://chatgpt.com/codex/tasks/task_e_683fa3a4d054832fb7f46ca20a65952f